### PR TITLE
Fix two bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ _testmain.go
 
 *.exe
 *.test
+.idea/bplustree.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/watcherTasks.xml
+.idea/workspace.xml

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/heeeeeng/bplustree
+
+go 1.12

--- a/interior.go
+++ b/interior.go
@@ -112,8 +112,6 @@ func (in *interiorNode) split() (*interiorNode, int) {
 
 	// modify the original node
 	in.count = midIndex + 1
-	in.kcs[in.count-1].key = 0
-	in.kcs[in.count-1].child = midChild
 	midChild.setParent(in)
 
 	return next, midKey

--- a/interior.go
+++ b/interior.go
@@ -1,6 +1,7 @@
 package bplustree
 
 import (
+	"fmt"
 	"sort"
 )
 
@@ -26,6 +27,14 @@ func (a *kcs) Less(i, j int) bool {
 	}
 
 	return a[i].key < a[j].key
+}
+
+func (a *kcs) String() string {
+	var s string
+	for _, kc := range a {
+		s += fmt.Sprintf("%d\t", kc.key)
+	}
+	return s
 }
 
 type interiorNode struct {

--- a/leaf.go
+++ b/leaf.go
@@ -2,6 +2,7 @@ package bplustree
 
 import (
 	//"log"
+	"fmt"
 	"sort"
 )
 
@@ -15,6 +16,14 @@ type kvs [MaxKV]kv
 func (a *kvs) Len() int           { return len(a) }
 func (a *kvs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a *kvs) Less(i, j int) bool { return a[i].key < a[j].key }
+
+func (a *kvs) String() string {
+	var s string
+	for _, kv := range a {
+		s += fmt.Sprintf("%d\t", kv.key)
+	}
+	return s
+}
 
 type leafNode struct {
 	kvs   kvs

--- a/tree.go
+++ b/tree.go
@@ -72,7 +72,7 @@ func (bt *BTree) Insert(key int, value string) {
 			return
 		}
 
-		interior, interiorP = interiorP, interior.parent()
+		interior, interiorP = interiorP, interiorP.parent()
 	}
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -95,10 +95,6 @@ func verifyNode(n node, parent *interiorNode, t *testing.T) {
 			}
 			last = key
 
-			if i == nn.count-1 && key != 0 {
-				t.Errorf("interior.last.key: want = 0, got = %d", key)
-			}
-
 			verifyNode(nn.kcs[i].child, nn, t)
 		}
 


### PR DESCRIPTION
1. During inserting, the reassignment of "interiorP" should be "interiorP.parent()", rather than "interior.parent()" which is interiorP itself.

```
// before
interior, interiorP = interiorP, interior.parent()

// after
interior, interiorP = interiorP, interiorP.parent()
```

2. Delete the key and value assignment when splitting interior node.

Setting key to be 0 will cause a search problem. On the test case, I tried print out all the keys of a interior node, and the output is like this:
```
interior:     ...	56899	57026	0	57280	57407	...	89411	89538	0
```
There is a "0" key in the middle and a "0" key at the end. 

The first "0" key should be "57153" rather than "0". If you want to search a key which is 57100, then inside the search function it will skip this "0" key but pick "57280" as the smallest index that has the key larger than 57100. And then it will stop the search because there is no leaf node containing 57100 key in branch "57280". The "57100" key is actually contained in the leaves of branch "0".

